### PR TITLE
Hadoop Internals : fix typos

### DIFF
--- a/hadoop/deployments.tex
+++ b/hadoop/deployments.tex
@@ -300,7 +300,7 @@
 
 \vspace{40pt}
 
-  \item \textbf{Cloud based Hadoop installations (Amazon biased)}
+  \item \textbf{Cloud based Hadoop installations (Amazon based)}
     \begin{itemize}
     \item Use Cloudera + \{Whirr, boto, ...\}
     \item Use Elastic MapReduce

--- a/hadoop/mapreduce.tex
+++ b/hadoop/mapreduce.tex
@@ -452,7 +452,7 @@
 \frame {\frametitle{Shuffle and Sort: the Reduce Side}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   \begin{itemize}
-  \item \textbf{The map output are copied to the the TraskTracker running the
+  \item \textbf{The map output are copied to the the TaskTracker running the
       reducer in {\color{red}memory} (if they fit)}
     \begin{itemize}
     \item Otherwise they are copied to disk


### PR DESCRIPTION
I have corrected 2 small typos in Hadoop slides.